### PR TITLE
#158532833 Add unresolved checks dashboard

### DIFF
--- a/hc/front/tests/test_unresolved_checks.py
+++ b/hc/front/tests/test_unresolved_checks.py
@@ -1,0 +1,26 @@
+from hc.api.models import Check
+from hc.test import BaseTestCase
+from datetime import timedelta 
+from django.utils import timezone
+
+class UnresolvedChecksTest(BaseTestCase):
+
+    def setUp(self):
+        super(UnresolvedChecksTest, self).setUp()
+        self.check = Check(user=self.alice, name='Failing Check')
+        self.check.save()
+
+    def test_unresolved_checks_works(self):
+        self.client.login(username="alice@example.org", password="password")
+        response = self.client.get("/unresolved/")
+        print(response)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_unresolved_check(self):
+        self.client.login(username="alice@example.org", password="password")
+        self.check.last_ping = timezone.now() - timedelta(days=3)
+        self.check.status = "up"
+        self.check.save()
+        self.check.refresh_from_db()
+        response = self.client.get("/unresolved/")
+        self.assertIn("Failing Check", response)

--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -34,7 +34,7 @@ urlpatterns = [
     url(r'^checks/add/$', views.add_check, name="hc-add-check"),
     url(r'^checks/([\w-]+)/', include(check_urls)),
     url(r'^integrations/', include(channel_urls)),
-
+    url(r'^unresolved/$', views.unresolved, name="hc-unresolved"),
     url(r'^docs/$', views.docs, name="hc-docs"),
     url(r'^docs/api/$', views.docs_api, name="hc-docs-api"),
     url(r'^about/$', views.about, name="hc-about"),

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -59,6 +59,18 @@ def my_checks(request):
 
     return render(request, "front/my_checks.html", ctx)
 
+@login_required
+def unresolved(request):
+    all_checks = list(Check.objects.filter(user=request.team.user).order_by("created"))
+    checks = []
+    for check in all_checks:
+        if check.get_status() == 'down':
+            checks.append(check)
+    ctx = {
+        "page": "unresolved",
+        "checks": checks
+    }
+    return render(request, "front/unresolved.html", ctx)
 
 def _welcome_check(request):
     check = None

--- a/templates/base.html
+++ b/templates/base.html
@@ -81,6 +81,10 @@
                         <a href="{% url 'hc-channels' %}">Integrations</a>
                     </li>
 
+                    <li {% if page == 'unresolved' %} class="active" {% endif %}>
+                        <a href="{% url 'hc-unresolved' %}">Unresolved</a>
+                    </li>
+
                 {% endif %}
 
 

--- a/templates/front/unresolved.html
+++ b/templates/front/unresolved.html
@@ -1,0 +1,283 @@
+{% extends "base.html" %}
+{% load compress staticfiles %}
+
+{% block title %}Unresolved Checks - healthchecks.io{% endblock %}
+
+
+{% block content %}
+<div class="row">
+    <div class="col-sm-12">
+        <h1>
+        {% if request.team == request.user.profile %}
+            Unresolved Checks
+        {% else %}
+            {{ request.team.team_name }}
+        {% endif %}
+        </h1>
+    </div>
+    {% if tags %}
+    <div id="my-checks-tags" class="col-sm-12">
+        {% for tag, count in tags %}
+            {% if tag in down_tags %}
+                <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button>
+            {% elif tag in grace_tags %}
+                <button class="btn btn-warning btn-xs" data-toggle="button">{{ tag }}</button>
+            {% else %}
+                <button class="btn btn-default btn-xs" data-toggle="button">{{ tag }}</button>
+            {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+
+</div>
+<div class="row">
+    <div class="col-sm-12">
+
+
+    {% if checks %}
+        {% include "front/my_checks_mobile.html" %}
+        {% include "front/my_checks_desktop.html" %}
+    {% else %}
+    <div class="alert alert-info">You don't have any unresolved check.</div>
+    {% endif %}
+    </div>
+</div>
+
+<div id="update-name-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="update-name-form" class="form-horizontal" method="post">
+            {% csrf_token %}
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="update-timeout-title">Name and Tags</h4>
+                </div>
+                <div class="modal-body">
+                        <div class="form-group">
+                            <label for="update-name-input" class="col-sm-2 control-label">
+                                Name
+                            </label>
+                            <div class="col-sm-9">
+                                <input
+                                    id="update-name-input"
+                                    name="name"
+                                    type="text"
+                                    value="---"
+                                    placeholder="unnamed"
+                                    class="input-name form-control" />
+
+                                <span class="help-block">
+                                    Give this check a human-friendly name,
+                                    so you can easily recognize it later.
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="update-tags-input" class="col-sm-2 control-label">
+                                Tags
+                            </label>
+                            <div class="col-sm-9">
+                                <input
+                                    id="update-tags-input"
+                                    name="tags"
+                                    type="text"
+                                    value=""
+                                    placeholder="production www"
+                                    class="form-control" />
+
+                                <span class="help-block">
+                                    Optionally, assign tags for easy filtering.
+                                    Separate multiple tags with spaces.
+                                </span>
+                            </div>
+                        </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="update-timeout-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="update-timeout-form" method="post">
+            {% csrf_token %}
+            <input type="hidden" name="timeout" id="update-timeout-timeout" />
+            <input type="hidden" name="grace" id="update-timeout-grace" />
+            <div class="modal-content">
+                <div class="modal-body">
+                    <div class="update-timeout-info text-center">
+                        <span
+                            class="update-timeout-label"
+                            data-toggle="tooltip"
+                            title="Expected time between pings.">
+                            Period
+                        </span>
+                        <span
+                            id="period-slider-value"
+                            class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+                    <div id="period-slider"></div>
+
+                    <div class="update-timeout-info text-center">
+                        <span
+                            class="update-timeout-label"
+                            data-toggle="tooltip"
+                            title="When check is late, how much time to wait until alert is sent">
+                            Grace Time
+                        </span>
+                        <span
+                            id="grace-slider-value"
+                            class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+
+                    <div id="grace-slider"></div>
+
+                    <div class="update-timeout-terms">
+                        <p>
+                            <span>Period</span>
+                            Expected time between pings.
+                        </p>
+                        <p>
+                            <span>Grace Time</span>
+                            When a check is late, how much time to wait until alert is sent.
+                        </p>
+                    </div>
+
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="remove-check-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="remove-check-form" method="post">
+            {% csrf_token %}
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="remove-check-title">Remove Check <span class="remove-check-name"></span></h4>
+                </div>
+                <div class="modal-body">
+                    <p>You are about to remove check
+                        <strong class="remove-check-name">---</strong>.
+                    </p>
+                    <p>Once it's gone there is no "undo" and you cannot get
+                    the old ping URL back.</p>
+                    <p>Are you sure?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Remove</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="show-usage-modal" class="modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <ul class="nav nav-pills" role="tablist">
+                    <li class="active">
+                        <a href="#crontab" data-toggle="tab">Crontab</a>
+                    </li>
+                    <li>
+                        <a href="#bash" data-toggle="tab">Bash</a>
+                    </li>
+                    <li>
+                        <a href="#python" data-toggle="tab">Python</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#node" data-toggle="tab">Node.js</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#php" data-toggle="tab">PHP</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#browser" data-toggle="tab">Browser</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#powershell" data-toggle="tab">PowerShell</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#email" data-toggle="tab">Email</a>
+                    </li>
+                </ul>
+
+            </div>
+            <div class="modal-body">
+
+
+                <div class="tab-content">
+                    {% with ping_url="<span class='ex'></span>" %}
+                    <div role="tabpanel" class="tab-pane active" id="crontab">
+                        {% include "front/snippets/crontab.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="bash">
+                        {% include "front/snippets/bash.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="python">
+                        {% include "front/snippets/python.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="node">
+                        {% include "front/snippets/node.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="php">
+                        {% include "front/snippets/php.html" %}
+                    </div>
+                    <div class="tab-pane" id="browser">
+                        {% include "front/snippets/browser.html" %}
+                    </div>
+                    <div class="tab-pane" id="powershell">
+                        {% include "front/snippets/powershell.html" %}
+                    </div>
+                    <div class="tab-pane" id="email">
+                            As an alternative to HTTP/HTTPS requests,
+                            you can "ping" this check by sending an
+                            email message to
+                            <div class="email-address">
+                                <code class="em"></code>
+                            </div>
+                    </div>
+                    {% endwith %}
+                </div>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Got It!</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<form id="pause-form" method="post">
+    {% csrf_token %}
+</form>
+
+{% endblock %}
+
+{% block scripts %}
+{% compress js %}
+<script src="{% static 'js/jquery-2.1.4.min.js' %}"></script>
+<script src="{% static 'js/bootstrap.min.js' %}"></script>
+<script src="{% static 'js/nouislider.min.js' %}"></script>
+<script src="{% static 'js/clipboard.min.js' %}"></script>
+<script src="{% static 'js/checks.js' %}"></script>
+{% endcompress %}
+{% endblock %}


### PR DESCRIPTION
#### What does this PR do?
This PR adds a new dashboard showing all unresolved checks.

#### Description of Task to be completed?
##### Currently:
When a User's job goes down, the user is sent a notification email informing him of the same

##### Expected:
Apart from the email notifications, the user should also have a separate dashboard view of their failed jobs

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/158532833

#### Screenshots (if appropriate)
<img width="1278" alt="screen shot 2018-07-05 at 2 06 45 pm" src="https://user-images.githubusercontent.com/8037062/42320102-d074c16e-805c-11e8-8624-b548a7eadf47.png">
